### PR TITLE
Removed return values on interface, since we now catch exceptions in calling code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ SHLIB_SUFFIX = so
 
 #  release numbers for libraries
 #
- LIBVERSION    = 5
+ LIBVERSION    = 6
  LIBRELEASE    = 0
  LIBSUBRELEASE = 0
 #

--- a/src/LibHdb++.cpp
+++ b/src/LibHdb++.cpp
@@ -67,29 +67,29 @@ HdbClient::HdbClient(vector<string> configuration)
 	}
 }
 
-int HdbClient::insert_Attr(Tango::EventData *data, HdbEventDataType ev_data_type)
+void HdbClient::insert_Attr(Tango::EventData *data, HdbEventDataType ev_data_type)
 {
-	return db->insert_Attr(data, ev_data_type);
+	db->insert_Attr(data, ev_data_type);
 }
 
-int HdbClient::insert_param_Attr(Tango::AttrConfEventData *data, HdbEventDataType ev_data_type)
+void HdbClient::insert_param_Attr(Tango::AttrConfEventData *data, HdbEventDataType ev_data_type)
 {
-	return db->insert_param_Attr(data, ev_data_type);
+	db->insert_param_Attr(data, ev_data_type);
 }
 
-int HdbClient::configure_Attr(string name, int type/*DEV_DOUBLE, DEV_STRING, ..*/, int format/*SCALAR, SPECTRUM, ..*/, int write_type/*READ, READ_WRITE, ..*/, unsigned int ttl/*hours, 0=infinity*/)
+void HdbClient::configure_Attr(string name, int type/*DEV_DOUBLE, DEV_STRING, ..*/, int format/*SCALAR, SPECTRUM, ..*/, int write_type/*READ, READ_WRITE, ..*/, unsigned int ttl/*hours, 0=infinity*/)
 {
-	return db->configure_Attr(name, type, format, write_type, ttl);
+	db->configure_Attr(name, type, format, write_type, ttl);
 }
 
-int HdbClient::updateTTL_Attr(string name, unsigned int ttl/*hours, 0=infinity*/)
+void HdbClient::updateTTL_Attr(string name, unsigned int ttl/*hours, 0=infinity*/)
 {
-	return db->updateTTL_Attr(name, ttl);
+	db->updateTTL_Attr(name, ttl);
 }
 
-int HdbClient::event_Attr(string name, unsigned char event)
+void HdbClient::event_Attr(string name, unsigned char event)
 {
-	return db->event_Attr(name, event);
+	db->event_Attr(name, event);
 }
 
 HdbClient::~HdbClient()

--- a/src/LibHdb++.h
+++ b/src/LibHdb++.h
@@ -58,15 +58,15 @@ class AbstractDB
 public:
 
 
-	virtual int insert_Attr(Tango::EventData *data, HdbEventDataType ev_data_type) = 0;
+	virtual void insert_Attr(Tango::EventData *data, HdbEventDataType ev_data_type) = 0;
 
-	virtual int insert_param_Attr(Tango::AttrConfEventData *data, HdbEventDataType ev_data_type) = 0;
+	virtual void insert_param_Attr(Tango::AttrConfEventData *data, HdbEventDataType ev_data_type) = 0;
 
-	virtual int configure_Attr(string name, int type/*DEV_DOUBLE, DEV_STRING, ..*/, int format/*SCALAR, SPECTRUM, ..*/, int write_type/*READ, READ_WRITE, ..*/, unsigned int ttl/*hours, 0=infinity*/) = 0;
+	virtual void configure_Attr(string name, int type/*DEV_DOUBLE, DEV_STRING, ..*/, int format/*SCALAR, SPECTRUM, ..*/, int write_type/*READ, READ_WRITE, ..*/, unsigned int ttl/*hours, 0=infinity*/) = 0;
 
-	virtual int updateTTL_Attr(string name, unsigned int ttl/*hours, 0=infinity*/) = 0;
+	virtual void updateTTL_Attr(string name, unsigned int ttl/*hours, 0=infinity*/) = 0;
 
-	virtual int event_Attr(string name, unsigned char event) = 0;
+	virtual void event_Attr(string name, unsigned char event) = 0;
 
 	virtual ~AbstractDB() {}
 
@@ -97,15 +97,15 @@ private:
 public:
 	HdbClient(vector<string> configuration);
 
-	int insert_Attr(Tango::EventData *data, HdbEventDataType ev_data_type);
+	void insert_Attr(Tango::EventData *data, HdbEventDataType ev_data_type);
 
-	int insert_param_Attr(Tango::AttrConfEventData *data, HdbEventDataType ev_data_type);
+	void insert_param_Attr(Tango::AttrConfEventData *data, HdbEventDataType ev_data_type);
 
-	int configure_Attr(string name, int type/*DEV_DOUBLE, DEV_STRING, ..*/, int format/*SCALAR, SPECTRUM, ..*/, int write_type/*READ, READ_WRITE, ..*/, unsigned int ttl/*hours, 0=infinity*/);
+	void configure_Attr(string name, int type/*DEV_DOUBLE, DEV_STRING, ..*/, int format/*SCALAR, SPECTRUM, ..*/, int write_type/*READ, READ_WRITE, ..*/, unsigned int ttl/*hours, 0=infinity*/);
 
-	int updateTTL_Attr(string name, unsigned int ttl/*hours, 0=infinity*/);
+	void updateTTL_Attr(string name, unsigned int ttl/*hours, 0=infinity*/);
 
-	int event_Attr(string name, unsigned char event);
+	void event_Attr(string name, unsigned char event);
 
 	~HdbClient();
 


### PR DESCRIPTION
Working through changes from the libhdbpp drivers, which no longer return ints in their API